### PR TITLE
Fix strange failure to run tests the first time

### DIFF
--- a/compileHasher.js
+++ b/compileHasher.js
@@ -1,0 +1,21 @@
+// Generates Hasher artifact at compile-time using Truffle's external compiler
+// mechanism
+const path = require('path')
+const fs = require('fs')
+const genContract = require('circomlib/src/mimcsponge_gencontract.js')
+
+// where Truffle will expect to find the results of the external compiler
+// command
+const outputPath = path.join(__dirname, 'build', 'Hasher.json')
+
+function main () {
+  const contract = {
+    contractName: 'Hasher',
+    abi: genContract.abi,
+    bytecode: genContract.createCode('mimcsponge', 220)
+  }
+
+  fs.writeFileSync(outputPath, JSON.stringify(contract))
+}
+
+main()

--- a/migrations/2_deploy_hasher.js
+++ b/migrations/2_deploy_hasher.js
@@ -1,21 +1,6 @@
 /* global artifacts */
-const path = require('path')
+const Hasher = artifacts.require('Hasher')
 
-const genContract = require('circomlib/src/mimcsponge_gencontract.js')
-const Artifactor = require('@truffle/artifactor')
-
-module.exports = function(deployer) {
-  return deployer.then( async () =>  {
-    const contractsDir = path.join(__dirname, '..', 'build/contracts')
-    let artifactor = new Artifactor(contractsDir)
-    let contractName = 'Hasher'
-    await artifactor.save({
-      contractName,
-      abi: genContract.abi,
-      unlinked_binary: genContract.createCode('mimcsponge', 220),
-    }).then(async () => {
-      const hasherContract = artifacts.require(contractName)
-      await deployer.deploy(hasherContract)
-    })
-  })
+module.exports = async function(deployer) {
+  await deployer.deploy(Hasher)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,16 +151,6 @@
         "defer-to-connect": "^1.0.1"
       }
     },
-    "@truffle/artifactor": {
-      "version": "4.0.38",
-      "resolved": "https://registry.npmjs.org/@truffle/artifactor/-/artifactor-4.0.38.tgz",
-      "integrity": "sha512-blkKmw0CdiJ4V2Xz9s8aHhcHHE3nr5jgQrgyI2fQhW3gfWLUUl9TQ+TLgNBDd90+aUqhPyTQRzy8lH1Z4xxmmg==",
-      "requires": {
-        "@truffle/contract-schema": "^3.0.18",
-        "fs-extra": "6.0.1",
-        "lodash": "^4.17.13"
-      }
-    },
     "@truffle/blockchain-utils": {
       "version": "0.0.14",
       "resolved": "https://registry.npmjs.org/@truffle/blockchain-utils/-/blockchain-utils-0.0.14.tgz",
@@ -3682,16 +3672,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
-    },
-    "fs-extra": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
-      "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      }
     },
     "fs-minipass": {
       "version": "1.2.7",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "license": "ISC",
   "dependencies": {
     "@openzeppelin/contracts": "^2.4.0",
-    "@truffle/artifactor": "^4.0.38",
     "@truffle/contract": "^4.0.39",
     "@truffle/hdwallet-provider": "^1.0.24",
     "axios": "^0.19.0",

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -95,6 +95,12 @@ module.exports = {
         },
         // evmVersion: "byzantium"
       }
+    },
+    external: {
+      command: 'node ./compileHasher.js',
+      targets: [{
+        path: './build/Hasher.json'
+      }]
     }
   }
 }


### PR DESCRIPTION
Hi!

I noticed your note in step 5 of your [usage instructions](https://github.com/tornadocash/tornado-core#usage), that tests sometimes fail the first time. Upon playing around with your project, I was able to reproduce what seems like the issue:

```
Error:
    at Deployer._preFlightCheck (/Users/gnidan/src/work/truffle/packages/deployer/src/deployment.js:179:13)
    at processTicksAndRejections (internal/process/task_queues.js:86:5)
```

I am able to reproduce this error 100% of the time by runnning `truffle test --compile-all`.

If that's the error your README talks about, it turns out to be related to [`migrations/2_deploy_hasher.js`](https://github.com/tornadocash/tornado-core/blob/a94281c/migrations/2_deploy_hasher.js), which manually invokes @truffle/artifactor. This causes problems because `truffle test` uses a temporary directory for the artifacts, and your migration script isn't accounting for that.

This problem (and the need for the clever migration! 😉) goes away if you just generate Hasher when you run `truffle compile`. This PR does just that by hooking up Truffle's [external compiler system](https://www.trufflesuite.com/docs/truffle/reference/configuration#external-compilers) with a custom script.

I've tested this change with the command above and everything works as expected. (Note: I may be missing edge cases, since I'm not that familiar with this project).

Let me know if you want me to move things around and/or update style, etc.!

Oh, **addendum note**: this will likely also mean you can use `truffle develop` with more success, and/or not have to run `ganache-cli` separately all the time.