### PR TITLE
Allow mutability for state variables

### DIFF
--- a/contracts/ERC20Tornado.sol
+++ b/contracts/ERC20Tornado.sol
@@ -18,7 +18,7 @@ import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 
 contract ERC20Tornado is Tornado {
   using SafeERC20 for IERC20;
-  IERC20 public immutable token;
+  IERC20 public token;
 
   constructor(
     IVerifier _verifier,

--- a/contracts/MerkleTreeWithHistory.sol
+++ b/contracts/MerkleTreeWithHistory.sol
@@ -19,9 +19,9 @@ interface IHasher {
 contract MerkleTreeWithHistory {
   uint256 public constant FIELD_SIZE = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
   uint256 public constant ZERO_VALUE = 21663839004416932945382355908790599225266501822907911457504978515578255421292; // = keccak256("tornado") % FIELD_SIZE
-
   IHasher public immutable hasher;
-  uint32 public immutable levels;
+
+  uint32 public levels;
 
   // the following variables are made public for easier testing and debugging and
   // are not supposed to be accessed in regular code

--- a/contracts/Tornado.sol
+++ b/contracts/Tornado.sol
@@ -21,7 +21,7 @@ interface IVerifier {
 
 abstract contract Tornado is MerkleTreeWithHistory, ReentrancyGuard {
   IVerifier public immutable verifier;
-  uint256 public immutable denomination;
+  uint256 public denomination;
 
   mapping(bytes32 => bool) public nullifierHashes;
   // we store all commitments just to prevent accidental deposits with the same commitment


### PR DESCRIPTION
PR to add a separate branch called ``instances`` which enables the mutability of the ``denomination``, ``levels`` and ``token`` state variables to enable initializable instances.

PR should be closed and separate branch should be added, or this account added as contributor which can add branch.