### PR TITLE
fixes README regarding installation of snarkjs for build-process

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Underlying circomlib dependency is currently being audited, and the team already
 
 1. `node v11.15.0`
 2. `npm install -g npx`
+3. `npm install -g snarkjs`
 
 ## Usage
 


### PR DESCRIPTION
`npm run build` requires snarkjs installed globally.

That's why I made a comment in the requirements section of README.